### PR TITLE
Fixed bugs

### DIFF
--- a/src/containers/CoverageView/index.tsx
+++ b/src/containers/CoverageView/index.tsx
@@ -21,7 +21,6 @@ import countryLookupTable from 'data/admin0-lookup-table.json';
 import { CoverageViewColors } from 'models/Colors';
 import MapPopup from 'components/MapPopup';
 import { LegendRow } from 'models/LegendRow';
-import { CountryDataRow } from 'models/CountryData';
 import Legend from 'components/Legend';
 import iso from 'iso-3166-1';
 
@@ -66,21 +65,15 @@ const CoverageView: React.FC = () => {
 
     // Fly to country
     useEffect(() => {
-        if (selectedCountry) {
-            const getCountryCoordinates = (contriesList: CountryDataRow[]) => {
-                const finalCountry = contriesList.filter(
-                    (el) => el.code === selectedCountry,
-                );
-                return {
-                    center: [
-                        finalCountry[0].long,
-                        finalCountry[0].lat,
-                    ] as LngLatLike,
-                    zoom: 5,
-                };
-            };
-            map.current?.flyTo(getCountryCoordinates(countriesData));
-        }
+        if (!selectedCountry) return;
+
+        const lat = lookupTableData[selectedCountry].centroid[1];
+        const long = lookupTableData[selectedCountry].centroid[0];
+
+        map.current?.flyTo({
+            center: [long, lat] as LngLatLike,
+            zoom: 5,
+        });
     }, [selectedCountry]);
 
     // Setup map

--- a/src/containers/RegionalView/index.tsx
+++ b/src/containers/RegionalView/index.tsx
@@ -212,10 +212,12 @@ export const RegionalView: React.FC = () => {
                 searchQuery = `cases?country=${parseSearchQuery(
                     country,
                 )}${admin1Query}${admin2Query}${admin3Query}`;
-            } else {
+            } else if (country !== region) {
                 searchQuery = `cases?country=${parseSearchQuery(
                     country,
                 )}&${searchResolution}=${region}`;
+            } else {
+                searchQuery = `cases?country=${parseSearchQuery(country)}`;
             }
 
             const url = `${dataPortalUrl}/${searchQuery}`;


### PR DESCRIPTION
Completeness data has some countries that are not present in Countries data. Because of that when a user clicks on such a country in Coverage View's Sidebar error appeared. This PR loads coordinates for selected countries from Mapbox's lookup table instead of countries data as it is done in other views. This allowed to resolve this problem. 

Also I've found out that when a user selects a field in Coverage View some countries that appear in the list in Sidebar are not present in the Autocomplete field. This is fixed in this PR as well.