### PR TITLE
2387 hide cursor from covid title

### DIFF
--- a/src/components/SideBar/styled.ts
+++ b/src/components/SideBar/styled.ts
@@ -56,7 +56,7 @@ export const FlagIcon = styled('img')(() => ({
 }));
 
 export const SideBarHeader = styled('div')(({ theme }) => ({
-    cursor: 'pointer',
+    cursor: 'default',
     height: 'auto',
     position: 'relative',
     h1: {


### PR DESCRIPTION
Made cursor default for non clickable header:
![image](https://user-images.githubusercontent.com/51946947/150978095-509c4f6f-8fec-4829-98f3-6d9741b36c17.png)
