### PR TITLE
Layers order bug fix

### DIFF
--- a/src/containers/CountryView/index.tsx
+++ b/src/containers/CountryView/index.tsx
@@ -208,7 +208,7 @@ const CountryView: React.FC = () => {
                     'fill-outline-color': CountryViewColors.Outline,
                 },
             },
-            'waterway-label',
+            'admin-1-boundary',
         );
 
         //Filter out countries without any data

--- a/src/containers/CoverageView/index.tsx
+++ b/src/containers/CoverageView/index.tsx
@@ -323,7 +323,7 @@ const CoverageView: React.FC = () => {
                     'fill-outline-color': CoverageViewColors.Outline,
                 },
             },
-            'waterway-label',
+            'admin-1-boundary',
         );
 
         //Filter out countries without any data

--- a/src/containers/VariantsView/index.tsx
+++ b/src/containers/VariantsView/index.tsx
@@ -128,7 +128,7 @@ const VariantsView: React.FC = () => {
                                 },
                             },
                         },
-                        'country-label',
+                        'admin-1-boundary',
                     );
                 }
 
@@ -148,7 +148,7 @@ const VariantsView: React.FC = () => {
                                 },
                             },
                         },
-                        'waterway-label',
+                        'admin-1-boundary',
                     );
                 }
 


### PR DESCRIPTION
Recently I noticed that sometimes layer with colors doesn't load on the map. It turned out that the layers were placed in the wrong order and sometimes if one layer loaded faster it would overlap the layer with actual data. This small PR fixes that.